### PR TITLE
add deploy script to PaddlePaddle.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: ruby
+cache: ccache
+sudo: required
+dist: trusty
+os:
+  - linux
+
+rvm:
+  - 2.4.1
+
+addons:
+  ssh_known_hosts: 52.76.173.135
+
+install:
+  - rvm install 2.4.1
+  - rvm use 2.4.1
+  - gem install bundler
+  - bundle check || bundle install
+
+script:
+  - |
+    export DEPLOY_DOCS_SH=https://raw.githubusercontent.com/PaddlePaddle/PaddlePaddle.org/master/scripts/deploy/deploy_docs.sh
+    export BLOG_DIR=`pwd`
+    cd ..
+    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" != "master" ]]; then echo "not master branch, no deploy"; exit 0; fi;
+    curl $DEPLOY_DOCS_SH | bash -s $CONTENT_DEC_PASSWD $TRAVIS_BRANCH $BLOG_DIR
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
PaddlePaddle.org uses 'blog' repo as a content source. This script will deploy the blog content to make it live on the new PaddlePaddle.org website.